### PR TITLE
fix: remove SLSA provenance and draft release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
-      hashes: ${{ steps.hashes.outputs.hashes }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -77,15 +76,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate binary hashes
-        if: steps.check_tag.outputs.exists == 'false'
-        id: hashes
-        env:
-          ARTIFACTS: "${{ steps.goreleaser.outputs.artifacts }}"
-        run: |
-          checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
-          echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
-
       - name: Comment on PR
         if: steps.check_tag.outputs.exists == 'false'
         env:
@@ -96,30 +86,3 @@ jobs:
         run: |
           gh pr comment "$PR_NUMBER" \
             --body "Released as [${VERSION}](https://github.com/${REPO}/releases/tag/${VERSION})"
-
-  provenance:
-    needs: release
-    if: needs.release.outputs.tag != ''
-    permissions:
-      actions: read
-      id-token: write
-      contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
-    with:
-      base64-subjects: "${{ needs.release.outputs.hashes }}"
-      upload-assets: true
-
-  publish-release:
-    needs: [release, provenance]
-    if: needs.release.outputs.tag != ''
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.release.outputs.tag }}
-          REPO: ${{ github.repository }}
-        run: |
-          gh release edit "$TAG" --repo "$REPO" --draft=false

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,8 +22,5 @@ archives:
 checksum:
   name_template: checksums.txt
 
-release:
-  draft: true
-
 changelog:
   sort: asc


### PR DESCRIPTION
## Summary

Remove SLSA provenance generation and draft-then-publish release flow from the release workflow. This simplifies the release pipeline by publishing releases directly via GoReleaser instead of creating draft releases with SLSA attestation.

## Changes

- Remove `provenance` job that generated SLSA v2.1.0 attestations using `slsa-github-generator`
- Remove `publish-release` job that promoted draft releases to published
- Remove `hashes` output from `release` job (no longer needed without provenance)
- Remove `release.draft: true` from `.goreleaser.yml` so releases are published immediately

## Breaking Changes

- SLSA provenance attestations will no longer be generated for releases
- Release assets will no longer include provenance files

## Test Plan

- Verify the release workflow triggers correctly when a release PR is merged
- Confirm GoReleaser publishes the release directly (not as draft)
- Verify release assets are uploaded correctly without provenance files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/azu/dockerfile-pin/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
