### PR TITLE
Refactor file parsing and application logic for better code reuse

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -67,16 +67,7 @@ func runCheck(cmd *cobra.Command, args []string) error {
 	var allResults []CheckResult
 	var needsCheck []int // indices into allResults that need registry verification
 	for _, filePath := range files {
-		var fileResults []CheckResult
-		var err error
-		switch DetectFileType(filePath) {
-		case FileTypeCompose:
-			fileResults, err = parseComposeForCheck(filePath, checkSyntaxOnly, checkIgnore)
-		case FileTypeActions:
-			fileResults, err = parseActionsForCheck(filePath, checkSyntaxOnly, checkIgnore)
-		default:
-			fileResults, err = parseDockerfileForCheck(filePath, checkSyntaxOnly, checkIgnore)
-		}
+		fileResults, err := parseFileForCheck(filePath, checkSyntaxOnly, checkIgnore)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error processing %s: %v\n", filePath, err)
 			continue
@@ -156,155 +147,78 @@ func runCheck(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// parseDockerfileForCheck parses a Dockerfile and returns CheckResults.
+// parseFileForCheck reads a file, parses it based on type, and returns CheckResults.
 // Results that need registry verification have Status="pending" and Message=digest.
-func parseDockerfileForCheck(filePath string, syntaxOnly bool, ignoreImages []string) ([]CheckResult, error) {
+func parseFileForCheck(filePath string, syntaxOnly bool, ignoreImages []string) ([]CheckResult, error) {
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", filePath, err)
 	}
 
-	instructions, err := dockerfile.Parse(strings.NewReader(string(content)))
-	if err != nil {
-		return nil, fmt.Errorf("parsing %s: %w", filePath, err)
+	var refs []imageReference
+	switch DetectFileType(filePath) {
+	case FileTypeCompose:
+		crefs, err := compose.Parse(content)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", filePath, err)
+		}
+		refs = composeToImageRefs(crefs)
+	case FileTypeActions:
+		arefs, err := actions.Parse(content)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", filePath, err)
+		}
+		refs = actionsToImageRefs(arefs)
+	default:
+		insts, err := dockerfile.Parse(strings.NewReader(string(content)))
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", filePath, err)
+		}
+		refs = dockerfileToImageRefs(insts)
 	}
 
+	return buildCheckResults(filePath, refs, syntaxOnly, ignoreImages), nil
+}
+
+// buildCheckResults converts a slice of imageReference into CheckResults.
+func buildCheckResults(filePath string, refs []imageReference, syntaxOnly bool, ignoreImages []string) []CheckResult {
 	var results []CheckResult
-	for _, inst := range instructions {
-		if inst.Skip {
+	for _, ref := range refs {
+		if ref.Skip {
 			results = append(results, CheckResult{
-				File: filePath, Line: inst.StartLine, Image: inst.ImageRef,
-				Status: "skip", Message: inst.SkipReason, Original: inst.Original,
+				File: filePath, Line: ref.Line, Image: ref.ImageRef,
+				Status: "skip", Message: ref.SkipReason, Original: ref.Original,
 			})
 			continue
 		}
-		if isIgnored(inst.ImageRef, ignoreImages) {
+		if isIgnored(ref.ImageRef, ignoreImages) {
 			results = append(results, CheckResult{
-				File: filePath, Line: inst.StartLine, Image: inst.ImageRef,
-				Status: "skip", Message: "ignored", Original: inst.Original,
+				File: filePath, Line: ref.Line, Image: ref.ImageRef,
+				Status: "skip", Message: "ignored", Original: ref.Original,
 			})
 			continue
 		}
-		if inst.Digest == "" {
+		if ref.Digest == "" {
 			results = append(results, CheckResult{
-				File: filePath, Line: inst.StartLine, Image: inst.ImageRef,
-				Status: "fail", Message: "missing digest", Original: inst.Original,
+				File: filePath, Line: ref.Line, Image: ref.ImageRef,
+				Status: "fail", Message: "missing digest", Original: ref.Original,
 			})
 			continue
 		}
 		if syntaxOnly {
 			results = append(results, CheckResult{
-				File: filePath, Line: inst.StartLine, Image: inst.ImageRef,
-				Status: "ok", Message: "", Original: inst.Original,
+				File: filePath, Line: ref.Line, Image: ref.ImageRef,
+				Status: "ok", Message: "", Original: ref.Original,
 			})
 			continue
 		}
 		// Needs registry check: store digest in Message temporarily
 		results = append(results, CheckResult{
-			File: filePath, Line: inst.StartLine, Image: inst.ImageRef,
-			Status: "pending", Message: inst.Digest, Original: inst.Original,
-		})
-	}
-	return results, nil
-}
-
-// parseComposeForCheck parses a compose file and returns CheckResults.
-// Results that need registry verification have Status="pending" and Message=digest.
-func parseComposeForCheck(filePath string, syntaxOnly bool, ignoreImages []string) ([]CheckResult, error) {
-	content, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, fmt.Errorf("reading %s: %w", filePath, err)
-	}
-	refs, err := compose.Parse(content)
-	if err != nil {
-		return nil, fmt.Errorf("parsing %s: %w", filePath, err)
-	}
-	var results []CheckResult
-	for _, ref := range refs {
-		if ref.Skip {
-			results = append(results, CheckResult{
-				File: filePath, Line: ref.Line, Image: ref.ImageRef,
-				Status: "skip", Message: ref.SkipReason, Original: "image: " + ref.RawRef,
-			})
-			continue
-		}
-		if isIgnored(ref.ImageRef, ignoreImages) {
-			results = append(results, CheckResult{
-				File: filePath, Line: ref.Line, Image: ref.ImageRef,
-				Status: "skip", Message: "ignored", Original: "image: " + ref.RawRef,
-			})
-			continue
-		}
-		if ref.Digest == "" {
-			results = append(results, CheckResult{
-				File: filePath, Line: ref.Line, Image: ref.ImageRef,
-				Status: "fail", Message: "missing digest", Original: "image: " + ref.RawRef,
-			})
-			continue
-		}
-		if syntaxOnly {
-			results = append(results, CheckResult{
-				File: filePath, Line: ref.Line, Image: ref.ImageRef,
-				Status: "ok", Message: "", Original: "image: " + ref.RawRef,
-			})
-			continue
-		}
-		results = append(results, CheckResult{
 			File: filePath, Line: ref.Line, Image: ref.ImageRef,
-			Status: "pending", Message: ref.Digest, Original: "image: " + ref.RawRef,
+			Status: "pending", Message: ref.Digest, Original: ref.Original,
 		})
 	}
-	return results, nil
-}
-
-func parseActionsForCheck(filePath string, syntaxOnly bool, ignoreImages []string) ([]CheckResult, error) {
-	content, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, fmt.Errorf("reading %s: %w", filePath, err)
-	}
-	refs, err := actions.Parse(content)
-	if err != nil {
-		return nil, fmt.Errorf("parsing %s: %w", filePath, err)
-	}
-	var results []CheckResult
-	for _, ref := range refs {
-		// Build Original with YAML key prefix for consistent output
-		// Location ends with the key name (e.g., "jobs.test.container.image" → "image")
-		original := actionsOriginal(ref)
-		if ref.Skip {
-			results = append(results, CheckResult{
-				File: filePath, Line: ref.Line, Image: ref.ImageRef,
-				Status: "skip", Message: ref.SkipReason, Original: original,
-			})
-			continue
-		}
-		if isIgnored(ref.ImageRef, ignoreImages) {
-			results = append(results, CheckResult{
-				File: filePath, Line: ref.Line, Image: ref.ImageRef,
-				Status: "skip", Message: "ignored", Original: original,
-			})
-			continue
-		}
-		if ref.Digest == "" {
-			results = append(results, CheckResult{
-				File: filePath, Line: ref.Line, Image: ref.ImageRef,
-				Status: "fail", Message: "missing digest", Original: original,
-			})
-			continue
-		}
-		if syntaxOnly {
-			results = append(results, CheckResult{
-				File: filePath, Line: ref.Line, Image: ref.ImageRef,
-				Status: "ok", Message: "", Original: original,
-			})
-			continue
-		}
-		results = append(results, CheckResult{
-			File: filePath, Line: ref.Line, Image: ref.ImageRef,
-			Status: "pending", Message: ref.Digest, Original: original,
-		})
-	}
-	return results, nil
+	return results
 }
 
 // actionsOriginal returns a human-readable "key: value" string for check output,

--- a/cmd/image_ref.go
+++ b/cmd/image_ref.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"github.com/azu/dockerfile-pin/internal/actions"
+	"github.com/azu/dockerfile-pin/internal/compose"
+	"github.com/azu/dockerfile-pin/internal/dockerfile"
+)
+
+// imageReference is a common representation of an image reference across file types
+// (Dockerfile, docker-compose, GitHub Actions).
+type imageReference struct {
+	ImageRef   string
+	Digest     string
+	Line       int
+	Skip       bool
+	SkipReason string
+	Original   string
+}
+
+func dockerfileToImageRefs(insts []dockerfile.FromInstruction) []imageReference {
+	refs := make([]imageReference, len(insts))
+	for i, inst := range insts {
+		refs[i] = imageReference{
+			ImageRef:   inst.ImageRef,
+			Digest:     inst.Digest,
+			Line:       inst.StartLine,
+			Skip:       inst.Skip,
+			SkipReason: inst.SkipReason,
+			Original:   inst.Original,
+		}
+	}
+	return refs
+}
+
+func composeToImageRefs(crefs []compose.ComposeImageRef) []imageReference {
+	refs := make([]imageReference, len(crefs))
+	for i, ref := range crefs {
+		refs[i] = imageReference{
+			ImageRef:   ref.ImageRef,
+			Digest:     ref.Digest,
+			Line:       ref.Line,
+			Skip:       ref.Skip,
+			SkipReason: ref.SkipReason,
+			Original:   "image: " + ref.RawRef,
+		}
+	}
+	return refs
+}
+
+func actionsToImageRefs(arefs []actions.ActionsImageRef) []imageReference {
+	refs := make([]imageReference, len(arefs))
+	for i, ref := range arefs {
+		refs[i] = imageReference{
+			ImageRef:   ref.ImageRef,
+			Digest:     ref.Digest,
+			Line:       ref.Line,
+			Skip:       ref.Skip,
+			SkipReason: ref.SkipReason,
+			Original:   actionsOriginal(ref),
+		}
+	}
+	return refs
+}

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -90,14 +90,26 @@ func runRun(cmd *cobra.Command, args []string) error {
 
 	// Phase 3: Apply digests and output results
 	for _, pf := range parsed {
+		var refs []imageReference
+		var rewriteFn func(string, map[int]string) string
 		switch pf.fileType {
 		case FileTypeCompose:
-			applyCompose(pf, digestMap, dryRun, runUpdate)
+			refs = composeToImageRefs(pf.composeRefs)
+			rewriteFn = func(content string, digests map[int]string) string {
+				return compose.RewriteFile(content, pf.composeRefs, digests)
+			}
 		case FileTypeActions:
-			applyActions(pf, digestMap, dryRun, runUpdate)
+			refs = actionsToImageRefs(pf.actionsRefs)
+			rewriteFn = func(content string, digests map[int]string) string {
+				return actions.RewriteFile(content, pf.actionsRefs, digests)
+			}
 		default:
-			applyDockerfile(pf, digestMap, dryRun, runUpdate)
+			refs = dockerfileToImageRefs(pf.dockerInsts)
+			rewriteFn = func(content string, digests map[int]string) string {
+				return dockerfile.RewriteFile(content, pf.dockerInsts, digests)
+			}
 		}
+		applyFile(pf, buildDigestMap(refs, digestMap, runUpdate), rewriteFn, dryRun)
 	}
 	return nil
 }
@@ -184,35 +196,10 @@ func resolveParallel(ctx context.Context, res resolver.DigestResolver, refs []st
 	return results
 }
 
-func applyDockerfile(pf parsedFile, digestMap map[string]string, dryRun bool, update bool) {
+// buildDigestMap builds a map[int]string of index→digest for refs that need rewriting.
+func buildDigestMap(refs []imageReference, digestMap map[string]string, update bool) map[int]string {
 	digests := make(map[int]string)
-	for i, inst := range pf.dockerInsts {
-		if inst.Skip || (inst.Digest != "" && !update) {
-			continue
-		}
-		if d, ok := digestMap[inst.ImageRef]; ok {
-			digests[i] = d
-		}
-	}
-	if len(digests) == 0 {
-		return
-	}
-	result := dockerfile.RewriteFile(string(pf.content), pf.dockerInsts, digests)
-	if dryRun {
-		fmt.Printf("--- %s\n", pf.path)
-		fmt.Print(result)
-		return
-	}
-	if err := os.WriteFile(pf.path, []byte(result), 0644); err != nil {
-		fmt.Fprintf(os.Stderr, "error writing %s: %v\n", pf.path, err)
-		return
-	}
-	fmt.Printf("pinned %d image(s) in %s\n", len(digests), pf.path)
-}
-
-func applyActions(pf parsedFile, digestMap map[string]string, dryRun bool, update bool) {
-	digests := make(map[int]string)
-	for i, ref := range pf.actionsRefs {
+	for i, ref := range refs {
 		if ref.Skip || (ref.Digest != "" && !update) {
 			continue
 		}
@@ -220,36 +207,15 @@ func applyActions(pf parsedFile, digestMap map[string]string, dryRun bool, updat
 			digests[i] = d
 		}
 	}
-	if len(digests) == 0 {
-		return
-	}
-	result := actions.RewriteFile(string(pf.content), pf.actionsRefs, digests)
-	if dryRun {
-		fmt.Printf("--- %s\n", pf.path)
-		fmt.Print(result)
-		return
-	}
-	if err := os.WriteFile(pf.path, []byte(result), 0644); err != nil {
-		fmt.Fprintf(os.Stderr, "error writing %s: %v\n", pf.path, err)
-		return
-	}
-	fmt.Printf("pinned %d image(s) in %s\n", len(digests), pf.path)
+	return digests
 }
 
-func applyCompose(pf parsedFile, digestMap map[string]string, dryRun bool, update bool) {
-	digests := make(map[int]string)
-	for i, ref := range pf.composeRefs {
-		if ref.Skip || (ref.Digest != "" && !update) {
-			continue
-		}
-		if d, ok := digestMap[ref.ImageRef]; ok {
-			digests[i] = d
-		}
-	}
+// applyFile rewrites a file using the provided rewrite function, then writes or prints the result.
+func applyFile(pf parsedFile, digests map[int]string, rewriteFn func(content string, digests map[int]string) string, dryRun bool) {
 	if len(digests) == 0 {
 		return
 	}
-	result := compose.RewriteFile(string(pf.content), pf.composeRefs, digests)
+	result := rewriteFn(string(pf.content), digests)
 	if dryRun {
 		fmt.Printf("--- %s\n", pf.path)
 		fmt.Print(result)

--- a/cmd/pin_test.go
+++ b/cmd/pin_test.go
@@ -34,7 +34,12 @@ func TestApplyDockerfile_UpdateExistingDigest(t *testing.T) {
 		"python:3.12-slim": "sha256:newdigest222",
 	}
 
-	applyDockerfile(pf, digestMap, false, true)
+	refs := dockerfileToImageRefs(instructions)
+	digests := buildDigestMap(refs, digestMap, true)
+	rewriteFn := func(content string, digests map[int]string) string {
+		return dockerfile.RewriteFile(content, instructions, digests)
+	}
+	applyFile(pf, digests, rewriteFn, false)
 
 	result, err := os.ReadFile(path)
 	if err != nil {
@@ -74,7 +79,12 @@ func TestApplyDockerfile_SkipExistingDigestWithoutUpdate(t *testing.T) {
 		"golang:1.22":  "sha256:ccc333",
 	}
 
-	applyDockerfile(pf, digestMap, false, false)
+	refs := dockerfileToImageRefs(instructions)
+	digests := buildDigestMap(refs, digestMap, false)
+	rewriteFn := func(content string, digests map[int]string) string {
+		return dockerfile.RewriteFile(content, instructions, digests)
+	}
+	applyFile(pf, digests, rewriteFn, false)
 
 	result, err := os.ReadFile(path)
 	if err != nil {


### PR DESCRIPTION
## Summary
This PR refactors the file parsing and digest application logic to eliminate code duplication across Dockerfile, docker-compose, and GitHub Actions file handlers. A new `imageReference` abstraction is introduced to provide a unified representation of image references across all file types.

## Key Changes

- **New `imageReference` abstraction**: Created a common struct to represent image references uniformly across Dockerfile, docker-compose, and GitHub Actions formats, with conversion functions (`dockerfileToImageRefs`, `composeToImageRefs`, `actionsToImageRefs`)

- **Unified parsing in `check` command**: Consolidated three separate parsing functions (`parseDockerfileForCheck`, `parseComposeForCheck`, `parseActionsForCheck`) into a single `parseFileForCheck` function that detects file type and delegates to appropriate parsers

- **Extracted common result building logic**: Created `buildCheckResults` function to handle the common logic for converting image references to `CheckResult` objects, eliminating ~150 lines of duplicated code

- **Unified digest application in `pin` command**: Replaced three separate apply functions (`applyDockerfile`, `applyActions`, `applyCompose`) with a single `applyFile` function that accepts a rewrite function callback, reducing duplication in file writing and output logic

- **Extracted digest map building**: Created `buildDigestMap` helper function to consolidate the logic for building the digest index map across all file types

- **Updated tests**: Modified `pin_test.go` to use the new unified functions while maintaining test coverage

## Implementation Details

- The `imageReference` struct includes all necessary fields: `ImageRef`, `Digest`, `Line`, `Skip`, `SkipReason`, and `Original`
- File type detection remains centralized via `DetectFileType`, with the unified functions handling the dispatch logic
- The refactoring maintains backward compatibility and doesn't change the external behavior or output format
- Conversion functions handle format-specific details (e.g., compose uses "image: " prefix for Original, actions uses `actionsOriginal()`)

https://claude.ai/code/session_016FiVAAokM354bmAWFaXCNG