### PR TITLE
docs: Add docker-compose.yml and GitHub Actions examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ services:
     ports:
       - "3000:3000"
   db:
-    image: postgres:16.2@sha256:12345abcdef...
+    image: postgres:16.2@sha256:4aea012537edfad80f98d870a36e6b90b4c09b27be7f4b4759d72db863baeebb
     environment:
       POSTGRES_PASSWORD: secret
   app:
@@ -133,7 +133,7 @@ jobs:
       db:
         image: postgres:18
     steps:
-      - uses: docker://ghcr.io/foo/bar:latest
+      - uses: docker://ghcr.io/astral-sh/uv:latest
       - uses: actions/checkout@v4
 ```
 
@@ -146,12 +146,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: node:24@sha256:aaa111...
+      image: node:24@sha256:bb20cf73b3ad7212834ec48e2174cdcb5775f6550510a5336b842ae32741ce6c
     services:
       db:
-        image: postgres:18@sha256:bbb222...
+        image: postgres:18@sha256:a9abf4275f9e99bff8e6aed712b3b7dfec9cac1341bba01c1ffdfce9ff9fc34a
     steps:
-      - uses: docker://ghcr.io/foo/bar:latest@sha256:ccc333...
+      - uses: docker://ghcr.io/astral-sh/uv:latest@sha256:90bbb3c16635e9627f49eec6539f956d70746c409209041800a0280b93152823
       - uses: actions/checkout@v4  # not a Docker image, skipped
 ```
 


### PR DESCRIPTION
## Summary
This PR expands the documentation by adding examples of `dockerfile-pin` usage with docker-compose and GitHub Actions workflows, in addition to the existing Dockerfile examples.

## Changes
- Added a new "#### Dockerfile" section header to better organize the existing Dockerfile example
- Added a new "#### docker-compose.yml" section with before/after examples showing how `dockerfile-pin` pins image digests in docker-compose services, including handling of the `build` directive (which is skipped when present)
- Added a new "#### GitHub Actions" section with before/after examples demonstrating digest pinning in GitHub Actions workflow files, including proper handling of Docker image references in container and services configurations, while skipping non-Docker image references like `actions/checkout@v4`

## Notable Details
- The examples demonstrate that `dockerfile-pin` intelligently skips images that have a `build` directive in docker-compose
- The GitHub Actions example shows that the tool correctly distinguishes between Docker image references (which get pinned) and action references (which are skipped)
- All examples follow the same before/after format for consistency with the existing documentation

https://claude.ai/code/session_01Y9Jr5JxLUeLwYNx36miXFz