### PR TITLE
ci: Use release PR body as GitHub Release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,12 +67,19 @@ jobs:
           go-version-file: go.mod
           cache: false
 
+      - name: Write release notes from PR body
+        if: steps.check_tag.outputs.exists == 'false'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          echo "$PR_BODY" > /tmp/release-notes.md
+
       - uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         if: steps.check_tag.outputs.exists == 'false'
         id: goreleaser
         with:
           version: "~> v2"
-          args: release --clean
+          args: release --clean --release-notes /tmp/release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,4 +23,4 @@ checksum:
   name_template: checksums.txt
 
 changelog:
-  sort: asc
+  disable: true


### PR DESCRIPTION
## Summary

Use the release PR body as the GitHub Release notes instead of the auto-generated changelog from goreleaser. This gives more control over release notes content by leveraging the PR body written during the release process.

## Changes

- Write the PR body to `/tmp/release-notes.md` during the release workflow
- Pass `--release-notes /tmp/release-notes.md` to goreleaser
- Disable goreleaser's built-in changelog generation

## Breaking Changes

None

## Test Plan

- Verify the next release uses the PR body as release notes on the GitHub Release page
- Confirm goreleaser no longer generates its own changelog