### PR TITLE
docs: improve CLI help text with detailed descriptions and examples

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -20,9 +20,38 @@ import (
 var checkCmd = &cobra.Command{
 	Use:   "check",
 	Short: "Check if FROM images are pinned to digests",
-	Long:  "Validate that Dockerfile FROM lines have @sha256:<digest> and that digests exist in the registry.",
-	Args:  cobra.NoArgs,
-	RunE:  runCheck,
+	Long: `Validate that every Docker image reference has a @sha256:<digest> and that the
+digest exists in the registry.
+
+Each image is reported as one of:
+  OK     digest present and verified in registry
+  FAIL   missing digest, or digest not found in registry
+  SKIP   scratch, multi-stage ref, ignored, or non-Docker uses
+  WARN   registry check failed (network error, auth issue, etc.)
+
+Exit code is 1 (configurable with --exit-code) when any image has FAIL status.
+Use --syntax-only to skip registry verification (only checks digest presence).
+Use --format json for machine-readable output (array of objects with
+file, line, image, status, message, original fields).`,
+	Example: `  # Check auto-detected files
+  dockerfile-pin check
+
+  # Check a specific file
+  dockerfile-pin check -f Dockerfile
+
+  # Check multiple files
+  dockerfile-pin check --glob '**/{Dockerfile,docker-compose.yml}'
+
+  # Syntax only (no network, fast)
+  dockerfile-pin check --syntax-only
+
+  # JSON output for CI integration
+  dockerfile-pin check --format json
+
+  # Ignore specific images
+  dockerfile-pin check --ignore-images "scratch" --ignore-images "ghcr.io/myorg/*"`,
+	Args: cobra.NoArgs,
+	RunE: runCheck,
 }
 
 var (

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -19,9 +19,41 @@ import (
 var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Pin FROM images to their digests",
-	Long:  "Parse Dockerfile FROM lines and add @sha256:<digest> to each image reference.\nBy default, shows changes without writing files (dry-run). Use --write to apply changes.",
-	Args:  cobra.NoArgs,
-	RunE:  runRun,
+	Long: `Resolve image tags to sha256 digests and add @sha256:<digest> to each reference.
+By default, prints the rewritten file to stdout without modifying it (dry-run).
+Use --write to apply changes in place.
+
+Supports Dockerfiles, docker-compose.yml/compose.yaml, GitHub Actions workflows,
+and action.yml files. File type is detected from filename.
+
+Skipped automatically:
+  - "FROM scratch" (no registry image)
+  - Multi-stage references ("FROM builder")
+  - ARG-only base images with no default value
+  - Compose services with a "build:" directive
+  - Non-docker "uses:" in GitHub Actions (e.g., actions/checkout@v4)
+  - Already-pinned images (use --update to re-resolve)
+
+Digests are resolved via HEAD requests and do not count against Docker Hub pull limits.`,
+	Example: `  # Preview changes for auto-detected files
+  dockerfile-pin run
+
+  # Apply changes
+  dockerfile-pin run --write
+
+  # Pin a specific file
+  dockerfile-pin run -f path/to/Dockerfile --write
+
+  # Pin all Dockerfiles and compose files
+  dockerfile-pin run --glob '**/{Dockerfile,docker-compose.yml}' --write
+
+  # Re-resolve existing digests (tag unchanged, digest updated)
+  dockerfile-pin run --write --update
+
+  # Ignore private registry images
+  dockerfile-pin run --ignore-images "*.dkr.ecr.*.amazonaws.com/**"`,
+	Args: cobra.NoArgs,
+	RunE: runRun,
 }
 
 var (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,35 @@ var version = "dev"
 var rootCmd = &cobra.Command{
 	Use:   "dockerfile-pin",
 	Short: "Pin Dockerfile and docker-compose images to digests",
-	Long:  "A CLI tool that adds @sha256:<digest> to FROM lines in Dockerfiles and image fields in docker-compose.yml to prevent supply chain attacks.",
+	Long: `Pin Docker image references to their sha256 digests to prevent supply chain attacks.
+
+Supported file types:
+  - Dockerfile          FROM image:tag → FROM image:tag@sha256:...
+  - docker-compose.yml  image: node:20 → image: node:20@sha256:...
+  - GitHub Actions      container/services/docker:// steps
+  - action.yml          runs.image: 'docker://...'
+
+File detection:
+  When neither -f nor --glob is given, auto-detects files via git ls-files
+  matching: Dockerfile, Dockerfile.*, docker-compose*.yml, compose.yaml,
+  action.yml, .github/workflows/*.yml, etc.
+  Outside a git repo, falls back to the same glob (skipping node_modules/, vendor/).
+
+Configuration:
+  Create .dockerfile-pin.yaml in project root to set persistent ignore rules:
+    ignore-images:
+      - "ghcr.io/myorg/*"           # glob patterns
+      - "!ghcr.io/myorg/public-*"   # negation (! prefix) re-enables checking
+  CLI --ignore-images flags are appended after config (last match wins).
+
+Authentication:
+  Uses ~/.docker/config.json for registry auth (Docker Hub, GHCR, GCR, ECR, etc.).
+  Run "docker login" or configure a credential helper before accessing private registries.
+
+Typical workflow:
+  dockerfile-pin run              # preview changes (dry-run)
+  dockerfile-pin run --write      # apply changes
+  dockerfile-pin check            # validate in CI`,
 }
 
 var versionCmd = &cobra.Command{


### PR DESCRIPTION
## Summary

Improve the CLI help text for the `check`, `run`, and root commands by adding detailed long descriptions, status code explanations, and usage examples.

## Changes

- Add comprehensive `Long` descriptions to `checkCmd`, `runCmd`, and `rootCmd` explaining supported file types, detection behavior, configuration, and authentication
- Add `Example` fields with practical usage patterns (dry-run, write, glob, JSON output, ignore patterns)
- Document status codes (OK, FAIL, SKIP, WARN) for the check command
- Document skip behavior (scratch, multi-stage, ARG-only, build directive, etc.) for the run command

## Breaking Changes

None

## Test Plan

- Run `dockerfile-pin --help`, `dockerfile-pin run --help`, `dockerfile-pin check --help` and verify the output is well-formatted
- Verify no functional changes by running `go build` and existing tests