### PR TITLE
CI: improve release workflow safety and enable changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          echo "$PR_BODY" > /tmp/release-notes.md
+          printenv PR_BODY > /tmp/release-notes.md
 
       - uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         if: steps.check_tag.outputs.exists == 'false'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,5 +22,3 @@ archives:
 checksum:
   name_template: checksums.txt
 
-changelog:
-  disable: true


### PR DESCRIPTION
## Summary

This PR fixes a shell safety issue in the release workflow and enables goreleaser's built-in changelog generation.

## Changes

- Replace `echo "$PR_BODY"` with `printenv PR_BODY` in release workflow to prevent shell interpretation of special characters (e.g., backticks, dollar signs) in PR body content when writing release notes
- Remove `changelog: disable: true` from `.goreleaser.yml` to enable goreleaser's automatic changelog generation for releases

## Breaking Changes

None

## Test Plan

- Verify the release workflow runs correctly by creating a release PR
- Confirm that release notes are properly written to `/tmp/release-notes.md` without shell interpretation issues
- Confirm goreleaser generates a changelog in the GitHub release