### PR TITLE
feat: add --min-age flag and -u shorthand for --update

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ dockerfile-pin run --glob '**/{Dockerfile,Dockerfile.*,docker-compose.yml,compos
 
 # Ignore specific images (glob patterns, repeatable)
 dockerfile-pin run --ignore-images "mcr.microsoft.com/**"
+
+# Re-resolve existing digests
+dockerfile-pin run --write --update
+
+# Skip images built within the last 7 days
+dockerfile-pin run --write --update --min-age 7
 ```
 
 #### Dockerfile
@@ -196,12 +202,13 @@ Create `.dockerfile-pin.yaml` (or `.dockerfile-pin.yml`) in your project root to
 
 ```yaml
 # .dockerfile-pin.yaml
+min-age: 7                                         # Skip images built within the last 7 days
 ignore-images:
   - "ghcr.io/myorg/*"                              # Ignore all images under myorg
   - "!ghcr.io/myorg/public-*"                      # But still check public-* images
-  - "*.dkr.ecr.*.amazonaws.com/**"                  # Ignore all ECR images
-  - "mcr.microsoft.com/**"                          # Ignore all Microsoft container images
-  - "scratch"                                        # Ignore exact image name
+  - "*.dkr.ecr.*.amazonaws.com/**"                 # Ignore all ECR images
+  - "mcr.microsoft.com/**"                         # Ignore all Microsoft container images
+  - "scratch"                                      # Ignore exact image name
 ```
 
 Config file patterns are merged with `--ignore-images` CLI flags. CLI flags are evaluated after config file patterns, so they take precedence (last match wins).
@@ -360,12 +367,32 @@ For private registries (GCR, GHCR, ECR), configure Docker credentials before run
 
 ## Digest Updates
 
-`--update` re-resolves each tag against the registry and replaces the existing digest with the current digest of that tag. The tag itself is not changed.
+`--update` (`-u`) re-resolves each tag against the registry and replaces the existing digest with the current digest of that tag. The tag itself is not changed.
 
 ```bash
 # Re-resolve all pinned digests from the registry
 dockerfile-pin run --write --update
 ```
+
+### `--min-age`
+
+`--min-age N` skips images whose build date is within the last N days. This acts as a cooldown period — only pin to images that have been stable for at least N days.
+
+```bash
+# Skip images built within the last 7 days
+dockerfile-pin run --write --update --min-age 7
+```
+
+The build date is read from the image's OCI config (`Created` field). Images with no creation timestamp (e.g., reproducible builds) are not skipped.
+
+`--min-age` can also be set in the configuration file:
+
+```yaml
+# .dockerfile-pin.yaml
+min-age: 7
+```
+
+CLI flag takes precedence over the configuration file value.
 
 For automated ongoing digest updates, use [Renovate](https://docs.renovatebot.com/docker/) which understands the `image:tag@sha256:digest` format.
 

--- a/cmd/ignore.go
+++ b/cmd/ignore.go
@@ -13,6 +13,7 @@ import (
 // Config represents .dockerfile-pin.yaml configuration.
 type Config struct {
 	IgnoreImages []string `yaml:"ignore-images"`
+	MinAge       *int     `yaml:"min-age,omitempty"`
 }
 
 // configFileNames is the list of config file names to search for.

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -61,6 +61,7 @@ var (
 	runGlob     string
 	runWrite    bool
 	runUpdate   bool
+	runMinAge   int
 	runIgnore   []string
 )
 
@@ -68,7 +69,8 @@ func init() {
 	runCmd.Flags().StringVarP(&runFilePath, "file", "f", "", "Dockerfile path (default: auto-detect)")
 	runCmd.Flags().StringVar(&runGlob, "glob", "", "Glob pattern to find Dockerfiles")
 	runCmd.Flags().BoolVar(&runWrite, "write", false, "Write changes to files (default is dry-run)")
-	runCmd.Flags().BoolVar(&runUpdate, "update", false, "Update existing digests")
+	runCmd.Flags().BoolVarP(&runUpdate, "update", "u", false, "Update existing digests")
+	runCmd.Flags().IntVar(&runMinAge, "min-age", 0, "Skip images built within the specified number of days")
 	runCmd.Flags().StringArrayVar(&runIgnore, "ignore-images", nil, "Images to ignore (glob patterns, repeatable)")
 	rootCmd.AddCommand(runCmd)
 }
@@ -97,6 +99,14 @@ func runRun(cmd *cobra.Command, args []string) error {
 	ignorePatterns := MergeIgnorePatterns(cfg.IgnoreImages, runIgnore)
 	if err := ValidatePatterns(ignorePatterns); err != nil {
 		return err
+	}
+
+	minAge := runMinAge
+	if !cmd.Flags().Changed("min-age") && cfg.MinAge != nil {
+		minAge = *cfg.MinAge
+	}
+	if minAge < 0 {
+		return fmt.Errorf("--min-age must be a non-negative integer")
 	}
 
 	dryRun := !runWrite
@@ -129,7 +139,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 	fmt.Printf("resolving %d unique image(s)...\n", len(refs))
 
 	res := &resolver.CraneResolver{}
-	digestMap := resolveParallel(ctx, res, refs)
+	digestMap := resolveParallel(ctx, res, refs, minAge)
 
 	// Phase 3: Apply digests and output results
 	for _, pf := range parsed {
@@ -199,11 +209,17 @@ func parseFile(filePath string, update bool, ignorePatterns []string) (parsedFil
 }
 
 // resolveParallel resolves digests for all image refs concurrently.
-func resolveParallel(ctx context.Context, res resolver.DigestResolver, refs []string) map[string]string {
+// When minAge > 0, uses a combined resolve+age-check to avoid redundant HEAD requests.
+func resolveParallel(ctx context.Context, res resolver.DigestResolver, refs []string, minAge int) map[string]string {
 	results := make(map[string]string)
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, runtime.NumCPU()*2)
+
+	var cutoff time.Time
+	if minAge > 0 {
+		cutoff = time.Now().AddDate(0, 0, -minAge)
+	}
 
 	for _, ref := range refs {
 		wg.Add(1)
@@ -212,14 +228,39 @@ func resolveParallel(ctx context.Context, res resolver.DigestResolver, refs []st
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			digest, err := res.Resolve(ctx, imageRef)
-			mu.Lock()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "WARN  %s  failed to resolve: %v\n", imageRef, err)
+			var digest string
+
+			if !cutoff.IsZero() {
+				// Combined resolve+age-check via remote.Image (avoids extra HEAD request)
+				d, created, err := resolver.ResolveWithCreatedTime(ctx, imageRef)
+				if err != nil {
+					mu.Lock()
+					fmt.Fprintf(os.Stderr, "WARN  %s  failed to resolve: %v\n", imageRef, err)
+					mu.Unlock()
+					return
+				}
+				if !created.IsZero() && created.After(cutoff) {
+					mu.Lock()
+					fmt.Printf("  skipped %s (built %s, within %d days)\n", imageRef, created.Format("2006-01-02"), minAge)
+					mu.Unlock()
+					return
+				}
+				digest = d
 			} else {
-				results[imageRef] = digest
-				fmt.Printf("  resolved %s → %s\n", imageRef, digest[:min(19, len(digest))])
+				// HEAD-only resolve (cheapest)
+				d, err := res.Resolve(ctx, imageRef)
+				if err != nil {
+					mu.Lock()
+					fmt.Fprintf(os.Stderr, "WARN  %s  failed to resolve: %v\n", imageRef, err)
+					mu.Unlock()
+					return
+				}
+				digest = d
 			}
+
+			mu.Lock()
+			results[imageRef] = digest
+			fmt.Printf("  resolved %s → %s\n", imageRef, digest[:min(19, len(digest))])
 			mu.Unlock()
 		}(ref)
 	}

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -209,7 +209,7 @@ func parseFile(filePath string, update bool, ignorePatterns []string) (parsedFil
 }
 
 // resolveParallel resolves digests for all image refs concurrently.
-// When minAge > 0, uses a combined resolve+age-check to avoid redundant HEAD requests.
+// When minAge > 0, images built within the last minAge days are skipped.
 func resolveParallel(ctx context.Context, res resolver.DigestResolver, refs []string, minAge int) map[string]string {
 	results := make(map[string]string)
 	var mu sync.Mutex
@@ -228,34 +228,26 @@ func resolveParallel(ctx context.Context, res resolver.DigestResolver, refs []st
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			var digest string
+			digest, err := res.Resolve(ctx, imageRef)
+			if err != nil {
+				mu.Lock()
+				fmt.Fprintf(os.Stderr, "WARN  %s  failed to resolve: %v\n", imageRef, err)
+				mu.Unlock()
+				return
+			}
 
 			if !cutoff.IsZero() {
-				// Combined resolve+age-check via remote.Image (avoids extra HEAD request)
-				d, created, err := resolver.ResolveWithCreatedTime(ctx, imageRef)
+				created, err := resolver.GetImageCreatedTime(ctx, imageRef)
 				if err != nil {
 					mu.Lock()
-					fmt.Fprintf(os.Stderr, "WARN  %s  failed to resolve: %v\n", imageRef, err)
+					fmt.Fprintf(os.Stderr, "WARN  %s  failed to get creation time, pinning anyway: %v\n", imageRef, err)
 					mu.Unlock()
-					return
-				}
-				if !created.IsZero() && created.After(cutoff) {
+				} else if !created.IsZero() && created.After(cutoff) {
 					mu.Lock()
 					fmt.Printf("  skipped %s (built %s, within %d days)\n", imageRef, created.Format("2006-01-02"), minAge)
 					mu.Unlock()
 					return
 				}
-				digest = d
-			} else {
-				// HEAD-only resolve (cheapest)
-				d, err := res.Resolve(ctx, imageRef)
-				if err != nil {
-					mu.Lock()
-					fmt.Fprintf(os.Stderr, "WARN  %s  failed to resolve: %v\n", imageRef, err)
-					mu.Unlock()
-					return
-				}
-				digest = d
 			}
 
 			mu.Lock()

--- a/cmd/pin_test.go
+++ b/cmd/pin_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -283,11 +284,11 @@ func TestApplyCompose_PreservesFilePermissions(t *testing.T) {
 }
 
 func TestResolveParallel_MinAge_SkipsTooNew(t *testing.T) {
-	original := resolver.ResolveWithCreatedTime
-	defer func() { resolver.ResolveWithCreatedTime = original }()
+	original := resolver.GetImageCreatedTime
+	defer func() { resolver.GetImageCreatedTime = original }()
 
-	resolver.ResolveWithCreatedTime = func(_ context.Context, _ string) (string, time.Time, error) {
-		return "sha256:abc123", time.Now().Add(-2 * 24 * time.Hour), nil // 2 days ago
+	resolver.GetImageCreatedTime = func(_ context.Context, _ string) (time.Time, error) {
+		return time.Now().Add(-2 * 24 * time.Hour), nil // 2 days ago
 	}
 
 	mock := &resolver.MockResolver{
@@ -300,11 +301,11 @@ func TestResolveParallel_MinAge_SkipsTooNew(t *testing.T) {
 }
 
 func TestResolveParallel_MinAge_AllowsOldEnough(t *testing.T) {
-	original := resolver.ResolveWithCreatedTime
-	defer func() { resolver.ResolveWithCreatedTime = original }()
+	original := resolver.GetImageCreatedTime
+	defer func() { resolver.GetImageCreatedTime = original }()
 
-	resolver.ResolveWithCreatedTime = func(_ context.Context, _ string) (string, time.Time, error) {
-		return "sha256:abc123", time.Now().Add(-10 * 24 * time.Hour), nil // 10 days ago
+	resolver.GetImageCreatedTime = func(_ context.Context, _ string) (time.Time, error) {
+		return time.Now().Add(-10 * 24 * time.Hour), nil // 10 days ago
 	}
 
 	mock := &resolver.MockResolver{
@@ -317,11 +318,11 @@ func TestResolveParallel_MinAge_AllowsOldEnough(t *testing.T) {
 }
 
 func TestResolveParallel_MinAge_ZeroCreatedAllowed(t *testing.T) {
-	original := resolver.ResolveWithCreatedTime
-	defer func() { resolver.ResolveWithCreatedTime = original }()
+	original := resolver.GetImageCreatedTime
+	defer func() { resolver.GetImageCreatedTime = original }()
 
-	resolver.ResolveWithCreatedTime = func(_ context.Context, _ string) (string, time.Time, error) {
-		return "sha256:abc123", time.Time{}, nil // zero value (reproducible build)
+	resolver.GetImageCreatedTime = func(_ context.Context, _ string) (time.Time, error) {
+		return time.Time{}, nil // zero value (reproducible build)
 	}
 
 	mock := &resolver.MockResolver{
@@ -334,13 +335,13 @@ func TestResolveParallel_MinAge_ZeroCreatedAllowed(t *testing.T) {
 }
 
 func TestResolveParallel_MinAge_ZeroDisabled(t *testing.T) {
-	original := resolver.ResolveWithCreatedTime
-	defer func() { resolver.ResolveWithCreatedTime = original }()
+	original := resolver.GetImageCreatedTime
+	defer func() { resolver.GetImageCreatedTime = original }()
 
 	called := false
-	resolver.ResolveWithCreatedTime = func(_ context.Context, _ string) (string, time.Time, error) {
+	resolver.GetImageCreatedTime = func(_ context.Context, _ string) (time.Time, error) {
 		called = true
-		return "sha256:abc123", time.Now(), nil
+		return time.Now(), nil
 	}
 
 	mock := &resolver.MockResolver{
@@ -348,9 +349,26 @@ func TestResolveParallel_MinAge_ZeroDisabled(t *testing.T) {
 	}
 	results := resolveParallel(context.Background(), mock, []string{"node:20"}, 0)
 	if called {
-		t.Error("ResolveWithCreatedTime should not be called when minAge is 0")
+		t.Error("GetImageCreatedTime should not be called when minAge is 0")
 	}
 	if results["node:20"] != "sha256:abc123" {
 		t.Errorf("expected node:20 to be resolved, got %q", results["node:20"])
+	}
+}
+
+func TestResolveParallel_MinAge_CreatedTimeErrorPinsAnyway(t *testing.T) {
+	original := resolver.GetImageCreatedTime
+	defer func() { resolver.GetImageCreatedTime = original }()
+
+	resolver.GetImageCreatedTime = func(_ context.Context, _ string) (time.Time, error) {
+		return time.Time{}, fmt.Errorf("network error")
+	}
+
+	mock := &resolver.MockResolver{
+		Digests: map[string]string{"node:20": "sha256:abc123"},
+	}
+	results := resolveParallel(context.Background(), mock, []string{"node:20"}, 7)
+	if results["node:20"] != "sha256:abc123" {
+		t.Errorf("expected node:20 to be pinned despite age-check failure, got %q", results["node:20"])
 	}
 }

--- a/cmd/pin_test.go
+++ b/cmd/pin_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/azu/dockerfile-pin/internal/actions"
 	"github.com/azu/dockerfile-pin/internal/compose"
@@ -107,7 +108,7 @@ func TestResolveParallel_ShortDigestNoPanic(t *testing.T) {
 	}
 	ctx := context.Background()
 	// Should complete without panicking.
-	results := resolveParallel(ctx, short, []string{"tiny:1", "tiny:2"})
+	results := resolveParallel(ctx, short, []string{"tiny:1", "tiny:2"}, 0)
 	if results["tiny:1"] != "sha256:ab" {
 		t.Errorf("expected sha256:ab, got %q", results["tiny:1"])
 	}
@@ -278,5 +279,78 @@ func TestApplyCompose_PreservesFilePermissions(t *testing.T) {
 	}
 	if got := fi.Mode().Perm(); got != 0600 {
 		t.Errorf("applyCompose changed permissions: got %04o, want 0600", got)
+	}
+}
+
+func TestResolveParallel_MinAge_SkipsTooNew(t *testing.T) {
+	original := resolver.ResolveWithCreatedTime
+	defer func() { resolver.ResolveWithCreatedTime = original }()
+
+	resolver.ResolveWithCreatedTime = func(_ context.Context, _ string) (string, time.Time, error) {
+		return "sha256:abc123", time.Now().Add(-2 * 24 * time.Hour), nil // 2 days ago
+	}
+
+	mock := &resolver.MockResolver{
+		Digests: map[string]string{"node:20": "sha256:abc123"},
+	}
+	results := resolveParallel(context.Background(), mock, []string{"node:20"}, 7)
+	if _, ok := results["node:20"]; ok {
+		t.Error("expected node:20 to be skipped (built 2 days ago, min-age 7)")
+	}
+}
+
+func TestResolveParallel_MinAge_AllowsOldEnough(t *testing.T) {
+	original := resolver.ResolveWithCreatedTime
+	defer func() { resolver.ResolveWithCreatedTime = original }()
+
+	resolver.ResolveWithCreatedTime = func(_ context.Context, _ string) (string, time.Time, error) {
+		return "sha256:abc123", time.Now().Add(-10 * 24 * time.Hour), nil // 10 days ago
+	}
+
+	mock := &resolver.MockResolver{
+		Digests: map[string]string{"node:20": "sha256:abc123"},
+	}
+	results := resolveParallel(context.Background(), mock, []string{"node:20"}, 7)
+	if results["node:20"] != "sha256:abc123" {
+		t.Errorf("expected node:20 to be resolved, got %q", results["node:20"])
+	}
+}
+
+func TestResolveParallel_MinAge_ZeroCreatedAllowed(t *testing.T) {
+	original := resolver.ResolveWithCreatedTime
+	defer func() { resolver.ResolveWithCreatedTime = original }()
+
+	resolver.ResolveWithCreatedTime = func(_ context.Context, _ string) (string, time.Time, error) {
+		return "sha256:abc123", time.Time{}, nil // zero value (reproducible build)
+	}
+
+	mock := &resolver.MockResolver{
+		Digests: map[string]string{"node:20": "sha256:abc123"},
+	}
+	results := resolveParallel(context.Background(), mock, []string{"node:20"}, 7)
+	if results["node:20"] != "sha256:abc123" {
+		t.Errorf("expected node:20 to be resolved (zero created time), got %q", results["node:20"])
+	}
+}
+
+func TestResolveParallel_MinAge_ZeroDisabled(t *testing.T) {
+	original := resolver.ResolveWithCreatedTime
+	defer func() { resolver.ResolveWithCreatedTime = original }()
+
+	called := false
+	resolver.ResolveWithCreatedTime = func(_ context.Context, _ string) (string, time.Time, error) {
+		called = true
+		return "sha256:abc123", time.Now(), nil
+	}
+
+	mock := &resolver.MockResolver{
+		Digests: map[string]string{"node:20": "sha256:abc123"},
+	}
+	results := resolveParallel(context.Background(), mock, []string{"node:20"}, 0)
+	if called {
+		t.Error("ResolveWithCreatedTime should not be called when minAge is 0")
+	}
+	if results["node:20"] != "sha256:abc123" {
+		t.Errorf("expected node:20 to be resolved, got %q", results["node:20"])
 	}
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -122,33 +122,27 @@ func (r *CachedResolver) Exists(ctx context.Context, imageRef string) (bool, err
 	return exists, err
 }
 
-// ResolveWithCreatedTime resolves the digest and creation time of an image in a single
-// remote.Image call, avoiding the extra HEAD request that a separate Resolve + age check would require.
-// Returns zero time.Time for created if the image config has no creation timestamp.
+// GetImageCreatedTime retrieves the creation time of a container image from its config.
+// Returns zero time.Time if the image config has no creation timestamp (e.g., reproducible builds).
 // This is a package-level variable so it can be replaced in tests.
-var ResolveWithCreatedTime = resolveWithCreatedTime
+var GetImageCreatedTime = getImageCreatedTime
 
-func resolveWithCreatedTime(ctx context.Context, imageRef string) (string, time.Time, error) {
+func getImageCreatedTime(ctx context.Context, imageRef string) (time.Time, error) {
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
-		return "", time.Time{}, fmt.Errorf("parsing reference %q: %w", imageRef, err)
+		return time.Time{}, fmt.Errorf("parsing reference %q: %w", imageRef, err)
 	}
 	reqCtx, cancel := context.WithTimeout(ctx, perRequestTimeout)
 	defer cancel()
 	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithContext(reqCtx))
 	if err != nil {
-		return "", time.Time{}, fmt.Errorf("fetching image %q: %w", imageRef, err)
-	}
-	digest, err := img.Digest()
-	if err != nil {
-		return "", time.Time{}, fmt.Errorf("reading digest for %q: %w", imageRef, err)
+		return time.Time{}, fmt.Errorf("fetching image %q: %w", imageRef, err)
 	}
 	cfg, err := img.ConfigFile()
 	if err != nil {
-		// Digest is available but config failed — return digest with zero time
-		return digest.String(), time.Time{}, nil
+		return time.Time{}, fmt.Errorf("reading config for %q: %w", imageRef, err)
 	}
-	return digest.String(), cfg.Created.Time, nil
+	return cfg.Created.Time, nil
 }
 
 type MockResolver struct {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -122,6 +122,35 @@ func (r *CachedResolver) Exists(ctx context.Context, imageRef string) (bool, err
 	return exists, err
 }
 
+// ResolveWithCreatedTime resolves the digest and creation time of an image in a single
+// remote.Image call, avoiding the extra HEAD request that a separate Resolve + age check would require.
+// Returns zero time.Time for created if the image config has no creation timestamp.
+// This is a package-level variable so it can be replaced in tests.
+var ResolveWithCreatedTime = resolveWithCreatedTime
+
+func resolveWithCreatedTime(ctx context.Context, imageRef string) (string, time.Time, error) {
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("parsing reference %q: %w", imageRef, err)
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, perRequestTimeout)
+	defer cancel()
+	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithContext(reqCtx))
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("fetching image %q: %w", imageRef, err)
+	}
+	digest, err := img.Digest()
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("reading digest for %q: %w", imageRef, err)
+	}
+	cfg, err := img.ConfigFile()
+	if err != nil {
+		// Digest is available but config failed — return digest with zero time
+		return digest.String(), time.Time{}, nil
+	}
+	return digest.String(), cfg.Created.Time, nil
+}
+
 type MockResolver struct {
 	Digests map[string]string
 }


### PR DESCRIPTION
## Summary

- Add `--min-age N` flag to skip images built within the last N days, acting as a cooldown period for digest pinning
- Add `-u` as a shorthand for `--update`
- Support `min-age` in `.dockerfile-pin.yaml` configuration file

### How `--min-age` works

Uses the image's OCI config `Created` field to determine build date. When active, uses a combined `remote.Image` call to resolve both digest and creation time in a single operation (no extra HEAD request).

- `--min-age 0` (default): no filtering
- `--min-age 7`: skip images built within the last 7 days
- Images with no creation timestamp (e.g., reproducible builds) are not skipped

### Limitations

- Tags with specific patch versions (e.g., `node:20.11.1`) are rarely re-tagged, so `--min-age` has limited effect on them
- Most useful for floating tags like `mysql:8.0`, `nginx:latest`, `ubuntu:24.04` that are periodically updated

### Example

```bash
# Re-resolve digests, but skip images built within the last 7 days
dockerfile-pin run --write --update --min-age 7
```

```yaml
# .dockerfile-pin.yaml
min-age: 7
```

## Test plan

- [x] `go test ./...` passes
- [x] `go build .` succeeds
- [x] `dockerfile-pin run -u --min-age 7` skips recently built images
- [x] `dockerfile-pin run --min-age 0` works as before
- [x] `dockerfile-pin run --help` shows new flags