### PR TITLE
feat: pin images in COPY instructions

### DIFF
--- a/internal/dockerfile/parse.go
+++ b/internal/dockerfile/parse.go
@@ -7,20 +7,21 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 )
 
-// FromInstruction represents a parsed FROM instruction in a Dockerfile.
+// FromInstruction represents a parsed FROM or COPY --from instruction in a Dockerfile.
 type FromInstruction struct {
 	ImageRef   string // image ref without digest, after ARG expansion (e.g., "node:20.11.1")
 	RawRef     string // as written in Dockerfile (may contain ${VAR}, may include digest)
 	Digest     string // existing digest if present (e.g., "sha256:abc...")
-	Platform   string // --platform value
-	StageName  string // AS clause name
+	Platform   string // --platform value (FROM only)
+	StageName  string // AS clause name (FROM only)
 	StartLine  int    // 1-based line number
-	Original   string // original FROM line text
+	Original   string // original instruction line text
 	Skip       bool
 	SkipReason string
+	IsCopyFrom bool // true when this instruction is COPY --from=<image>, not FROM
 }
 
-// Parse reads a Dockerfile from r and returns all FROM instructions.
+// Parse reads a Dockerfile from r and returns all FROM and COPY --from instructions.
 func Parse(r io.Reader) ([]FromInstruction, error) {
 	result, err := parser.Parse(r)
 	if err != nil {
@@ -29,17 +30,28 @@ func Parse(r io.Reader) ([]FromInstruction, error) {
 
 	argDefaults := map[string]string{}
 	stageNames := map[string]bool{}
-	var instructions []FromInstruction
-
 	for _, node := range result.AST.Children {
 		switch strings.ToLower(node.Value) {
 		case "arg":
 			parseArgNode(node, argDefaults)
 		case "from":
-			inst := parseFromNode(node, argDefaults, stageNames)
-			instructions = append(instructions, inst)
-			if inst.StageName != "" {
-				stageNames[strings.ToLower(inst.StageName)] = true
+			if node.Next != nil {
+				n := node.Next.Next
+				if n != nil && strings.ToLower(n.Value) == "as" && n.Next != nil {
+					stageNames[strings.ToLower(n.Next.Value)] = true
+				}
+			}
+		}
+	}
+
+	var instructions []FromInstruction
+	for _, node := range result.AST.Children {
+		switch strings.ToLower(node.Value) {
+		case "from":
+			instructions = append(instructions, parseFromNode(node, argDefaults, stageNames))
+		case "copy":
+			if inst, ok := parseCopyFromNode(node, argDefaults, stageNames); ok {
+				instructions = append(instructions, inst)
 			}
 		}
 	}
@@ -68,71 +80,26 @@ func parseFromNode(node *parser.Node, argDefaults map[string]string, stageNames 
 		Original:  node.Original,
 	}
 
-	// Extract --platform flag
 	for _, flag := range node.Flags {
 		if strings.HasPrefix(flag, "--platform=") {
 			inst.Platform = strings.TrimPrefix(flag, "--platform=")
 		}
 	}
 
-	// The image ref is the first token after FROM (node.Next)
 	if node.Next == nil {
 		inst.Skip = true
 		inst.SkipReason = "missing image reference"
 		return inst
 	}
 
-	rawRef := node.Next.Value
-	inst.RawRef = rawRef
+	inst.RawRef = node.Next.Value
 
-	// Check for AS clause (Next.Next = "as", Next.Next.Next = stage name)
 	n := node.Next.Next
 	if n != nil && strings.ToLower(n.Value) == "as" && n.Next != nil {
 		inst.StageName = n.Next.Value
 	}
 
-	// Handle scratch image
-	if strings.ToLower(rawRef) == "scratch" {
-		inst.Skip = true
-		inst.SkipReason = "scratch image"
-		inst.ImageRef = rawRef
-		return inst
-	}
-
-	// Expand ARG variables in the ref
-	expanded, hasUnresolved := expandVars(rawRef, argDefaults)
-
-	// Check if the expanded ref is a stage reference
-	// A stage reference is when the ref (without tag/digest) matches a known stage name
-	refWithoutDigest := expanded
-	if atIdx := strings.LastIndex(expanded, "@"); atIdx >= 0 {
-		refWithoutDigest = expanded[:atIdx]
-	}
-	// Stage names don't contain "/" or ":" or "."
-	refLower := strings.ToLower(refWithoutDigest)
-	if stageNames[refLower] {
-		inst.Skip = true
-		inst.SkipReason = "stage reference"
-		inst.ImageRef = expanded
-		return inst
-	}
-
-	// If expansion produced unresolved variables, skip
-	if hasUnresolved {
-		inst.Skip = true
-		inst.SkipReason = "unresolved ARG variable"
-		inst.ImageRef = expanded
-		return inst
-	}
-
-	// Split digest at "@" if present
-	if atIdx := strings.LastIndex(expanded, "@"); atIdx >= 0 {
-		inst.ImageRef = expanded[:atIdx]
-		inst.Digest = expanded[atIdx+1:]
-	} else {
-		inst.ImageRef = expanded
-	}
-
+	inst.ImageRef, inst.Digest, inst.SkipReason, inst.Skip = resolveRef(inst.RawRef, argDefaults, stageNames)
 	return inst
 }
 
@@ -204,4 +171,79 @@ func expandVars(s string, defaults map[string]string) (string, bool) {
 // isAlphaNumUnderscore returns true if b is a valid variable name character.
 func isAlphaNumUnderscore(b byte) bool {
 	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
+}
+
+// parseCopyFromNode parses a COPY node and returns a FromInstruction when the
+// instruction has a --from=<image> flag referencing an external image.
+// Returns (inst, true) if a --from flag is present, (zero, false) otherwise.
+func parseCopyFromNode(node *parser.Node, argDefaults map[string]string, stageNames map[string]bool) (FromInstruction, bool) {
+	var fromValue string
+	for _, flag := range node.Flags {
+		if after, ok := strings.CutPrefix(flag, "--from="); ok {
+			fromValue = after
+			break
+		}
+	}
+	if fromValue == "" {
+		return FromInstruction{}, false
+	}
+
+	inst := FromInstruction{
+		StartLine:  node.StartLine,
+		Original:   node.Original,
+		RawRef:     fromValue,
+		IsCopyFrom: true,
+	}
+
+	// Numeric index (e.g. --from=0) refers to a build stage, not an image.
+	if isNumeric(fromValue) {
+		inst.Skip = true
+		inst.SkipReason = "stage index reference"
+		return inst, true
+	}
+
+	inst.ImageRef, inst.Digest, inst.SkipReason, inst.Skip = resolveRef(fromValue, argDefaults, stageNames)
+	return inst, true
+}
+
+// resolveRef expands ARG variables in rawRef and classifies it as a pinnable
+// image, a stage reference, scratch, or skipped due to unresolved variables.
+// Returns (imageRef, digest, skipReason, skip).
+func resolveRef(rawRef string, argDefaults map[string]string, stageNames map[string]bool) (string, string, string, bool) {
+	expanded, hasUnresolved := expandVars(rawRef, argDefaults)
+
+	if strings.ToLower(expanded) == "scratch" {
+		return expanded, "", "scratch image", true
+	}
+
+	// Strip digest before comparing against stage names.
+	refWithoutDigest := expanded
+	if atIdx := strings.LastIndex(expanded, "@"); atIdx >= 0 {
+		refWithoutDigest = expanded[:atIdx]
+	}
+	if stageNames[strings.ToLower(refWithoutDigest)] {
+		return expanded, "", "stage reference", true
+	}
+
+	if hasUnresolved {
+		return expanded, "", "unresolved ARG variable", true
+	}
+
+	if atIdx := strings.LastIndex(expanded, "@"); atIdx >= 0 {
+		return expanded[:atIdx], expanded[atIdx+1:], "", false
+	}
+	return expanded, "", "", false
+}
+
+// isNumeric returns true if s consists entirely of ASCII digits.
+func isNumeric(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/dockerfile/parse_test.go
+++ b/internal/dockerfile/parse_test.go
@@ -150,6 +150,109 @@ func TestParse_PlatformVariable(t *testing.T) {
 	}
 }
 
+func TestParse_CopyFrom(t *testing.T) {
+	input := strings.Join([]string{
+		"FROM golang:1.22 AS builder",
+		"FROM nginx:alpine AS server",
+		"COPY --from=builder /app /app",
+		"COPY --from=0 /bin/tool /usr/local/bin/tool",
+		"COPY --from=nginx:alpine /etc/nginx /etc/nginx",
+		"COPY --from=gcr.io/distroless/base:nonroot /etc /etc",
+		"COPY --from=server /var/www /var/www",
+		"COPY /src /dst",
+		"",
+	}, "\n")
+
+	instructions, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	if len(instructions) != 7 {
+		t.Fatalf("expected 7 instructions, got %d", len(instructions))
+	}
+
+	if instructions[0].ImageRef != "golang:1.22" || instructions[0].IsCopyFrom {
+		t.Errorf("[0] unexpected: %+v", instructions[0])
+	}
+
+	if instructions[1].ImageRef != "nginx:alpine" || instructions[1].IsCopyFrom {
+		t.Errorf("[1] unexpected: %+v", instructions[1])
+	}
+
+	inst := instructions[2]
+	if !inst.IsCopyFrom || !inst.Skip || inst.SkipReason != "stage reference" {
+		t.Errorf("[2] COPY --from=builder: want IsCopyFrom=true Skip=true SkipReason=stage reference, got %+v", inst)
+	}
+
+	inst = instructions[3]
+	if !inst.IsCopyFrom || !inst.Skip || inst.SkipReason != "stage index reference" {
+		t.Errorf("[3] COPY --from=0: want IsCopyFrom=true Skip=true SkipReason=stage index reference, got %+v", inst)
+	}
+
+	inst = instructions[4]
+	if !inst.IsCopyFrom || inst.Skip || inst.ImageRef != "nginx:alpine" {
+		t.Errorf("[4] COPY --from=nginx:alpine: want IsCopyFrom=true Skip=false ImageRef=nginx:alpine, got %+v", inst)
+	}
+
+	inst = instructions[5]
+	if !inst.IsCopyFrom || inst.Skip || inst.ImageRef != "gcr.io/distroless/base:nonroot" {
+		t.Errorf("[5] COPY --from=gcr.io/...: want IsCopyFrom=true Skip=false ImageRef=gcr.io/distroless/base:nonroot, got %+v", inst)
+	}
+
+	inst = instructions[6]
+	if !inst.IsCopyFrom || !inst.Skip || inst.SkipReason != "stage reference" {
+		t.Errorf("[6] COPY --from=server: want IsCopyFrom=true Skip=true SkipReason=stage reference, got %+v", inst)
+	}
+}
+
+func TestParse_CopyFromAlreadyPinned(t *testing.T) {
+	input := "COPY --from=nginx:alpine@sha256:abc123def456 /etc/nginx /etc/nginx\n"
+	instructions, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(instructions) != 1 {
+		t.Fatalf("expected 1 instruction, got %d", len(instructions))
+	}
+	inst := instructions[0]
+	if inst.ImageRef != "nginx:alpine" {
+		t.Errorf("ImageRef = %q, want %q", inst.ImageRef, "nginx:alpine")
+	}
+	if inst.Digest != "sha256:abc123def456" {
+		t.Errorf("Digest = %q, want %q", inst.Digest, "sha256:abc123def456")
+	}
+	if !inst.IsCopyFrom {
+		t.Error("IsCopyFrom should be true")
+	}
+	if inst.Skip {
+		t.Error("should not be skipped")
+	}
+}
+
+func TestParse_CopyFromForwardStageRef(t *testing.T) {
+	// COPY --from references a stage defined LATER in the file; should still be
+	// detected as a stage reference thanks to the two-pass parsing.
+	input := strings.Join([]string{
+		"FROM alpine AS base",
+		"COPY --from=late /bin/tool /usr/local/bin/tool",
+		"FROM ubuntu AS late",
+		"",
+	}, "\n")
+	instructions, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	// 2 FROM + 1 COPY --from
+	if len(instructions) != 3 {
+		t.Fatalf("expected 3 instructions, got %d", len(instructions))
+	}
+	inst := instructions[1]
+	if !inst.IsCopyFrom || !inst.Skip || inst.SkipReason != "stage reference" {
+		t.Errorf("forward stage ref: want IsCopyFrom=true Skip=true SkipReason=stage reference, got %+v", inst)
+	}
+}
+
 func TestExpandVars(t *testing.T) {
 	defaults := map[string]string{"VERSION": "3.12", "REG": "ghcr.io"}
 	tests := []struct {

--- a/internal/dockerfile/rewrite_test.go
+++ b/internal/dockerfile/rewrite_test.go
@@ -52,6 +52,20 @@ func TestAddDigest(t *testing.T) {
 			digest:   "sha256:abc123",
 			want:     "FROM --platform=linux/amd64 golang:1.22@sha256:abc123 AS builder",
 		},
+		{
+			name:     "COPY --from simple tag",
+			original: "COPY --from=nginx:alpine /etc/nginx /etc/nginx",
+			rawRef:   "nginx:alpine",
+			digest:   "sha256:abc123",
+			want:     "COPY --from=nginx:alpine@sha256:abc123 /etc/nginx /etc/nginx",
+		},
+		{
+			name:     "COPY --from update existing digest",
+			original: "COPY --from=nginx:alpine@sha256:olddigest /etc/nginx /etc/nginx",
+			rawRef:   "nginx:alpine@sha256:olddigest",
+			digest:   "sha256:newdigest",
+			want:     "COPY --from=nginx:alpine@sha256:newdigest /etc/nginx /etc/nginx",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -77,6 +91,26 @@ func TestRewriteFile(t *testing.T) {
 
 	got := RewriteFile(content, instructions, digests)
 	want := "# My Dockerfile\nFROM node:20.11.1@sha256:abc123\nRUN npm install\nFROM python:3.12-slim@sha256:def456 AS builder\nRUN pip install -r requirements.txt\nFROM scratch\n"
+	if got != want {
+		t.Errorf("RewriteFile() =\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestRewriteFile_WithCopyFrom(t *testing.T) {
+	content := "FROM golang:1.22 AS builder\nCOPY --from=builder /app /app\nCOPY --from=nginx:alpine /etc/nginx /etc/nginx\nFROM debian:bookworm-slim\n"
+	instructions := []FromInstruction{
+		{ImageRef: "golang:1.22", RawRef: "golang:1.22", StartLine: 1},
+		{ImageRef: "builder", RawRef: "builder", StartLine: 2, IsCopyFrom: true, Skip: true, SkipReason: "stage reference"},
+		{ImageRef: "nginx:alpine", RawRef: "nginx:alpine", StartLine: 3, IsCopyFrom: true},
+		{ImageRef: "debian:bookworm-slim", RawRef: "debian:bookworm-slim", StartLine: 4},
+	}
+	digests := map[int]string{
+		0: "sha256:golang111",
+		2: "sha256:nginx222",
+		3: "sha256:debian333",
+	}
+	got := RewriteFile(content, instructions, digests)
+	want := "FROM golang:1.22@sha256:golang111 AS builder\nCOPY --from=builder /app /app\nCOPY --from=nginx:alpine@sha256:nginx222 /etc/nginx /etc/nginx\nFROM debian:bookworm-slim@sha256:debian333\n"
 	if got != want {
 		t.Errorf("RewriteFile() =\n%s\nwant:\n%s", got, want)
 	}


### PR DESCRIPTION
Hi,

This PR adds support for pinning images that are referenced in `COPY --from` instructions.

This PR was assisted by copilot using Claude Sonnet 4.6.